### PR TITLE
Summon name misspelled.

### DIFF
--- a/data/monster/traps/dwarf dispenser.xml
+++ b/data/monster/traps/dwarf dispenser.xml
@@ -21,6 +21,6 @@
 		<immunity invisible="1" />
 	</immunities>
 	<summons maxSummons="5">
-		<summon name="Dwarf Henchmen" interval="1000" chance="55" />
+		<summon name="Dwarf Henchman" interval="1000" chance="55" />
 	</summons>
 </monster>


### PR DESCRIPTION
Summon was incorrectly named Dwarf Henchmen.
Actually it is the plural name of the summon (Dwarf Henchman).